### PR TITLE
Added French translation of app titles for MiMa

### DIFF
--- a/ausparken/app.json
+++ b/ausparken/app.json
@@ -8,6 +8,7 @@
     "en": "Car park",
     "de": "Ausparken",
     "es": "Estacionamiento",
+    "fr": "Le parking",
     "zh": "停车场",
     "ru": "Распарковка",
     "ro": "Parcare",

--- a/doppelpendel/app.json
+++ b/doppelpendel/app.json
@@ -8,6 +8,7 @@
     "en": "Double pendulum",
     "de": "Doppelpendel",
     "es": "Péndulo doble",
+    "fr": "Le pendule double",
     "zh": "双摆",
     "ru": "Двойной маятник",
     "ro": "Pendulul dublu",

--- a/euclidian-rhythm/app.json
+++ b/euclidian-rhythm/app.json
@@ -8,6 +8,7 @@
     "en": "Euclidean Rhythm",
     "de": "Euklidischer Rhythmus",
     "es": "Ritmo Euclidiano",
+    "fr": "Rythmes Euclidiens",
     "ru": "Ритм Евклида",
     "ro": "Ritm euclidian",
     "it": "Ritmo euclideo"

--- a/image-spiral/app.json
+++ b/image-spiral/app.json
@@ -8,6 +8,7 @@
     "en": "Spiral",
     "de": "Spirale",
     "es": "Espiral",
+    "fr": "Spirale",
     "zh": "螺旋线",
     "ru": "Спираль",
     "ro": "Spirală",

--- a/kaleidoskop/app.json
+++ b/kaleidoskop/app.json
@@ -8,6 +8,7 @@
     "en": "Kaleidoscope",
     "de": "Kaleidoskop",
     "es": "Caleidoscopio",
+    "fr": "La kaléidoscope",
     "zh": "万花筒",
     "ru": "Калейдоскоп",
     "ro": "Caleidoscop",

--- a/mozart-dice/app.json
+++ b/mozart-dice/app.json
@@ -8,6 +8,7 @@
     "en": "Mozart's Dice",
     "de": "Mozarts Würfel",
     "es": "Dados de Mozart",
+    "fr": "Le dé de Mozart",
     "ru": "Кубики Моцарта",
     "ro": "Zarul lui Mozart",
     "it": "I dadi di Mozart"

--- a/pachelbel-canon/app.json
+++ b/pachelbel-canon/app.json
@@ -8,6 +8,7 @@
     "en": "Pachelbel's Canon",
     "de": "Kanon in D-Dur (Pachelbel)",
     "es": "Canon de Pachelbel",
+    "fr": "Le canon de Pachelbel",
     "ru": "Канон Пахельбеля",
     "ro": "Canonul lui Pachelbel",
     "it": "Il canone di Pachelbel"

--- a/sequenzer/app.json
+++ b/sequenzer/app.json
@@ -8,6 +8,7 @@
     "en": "Sequencer",
     "de": "Sequenzer",
     "es": "Secuenciador",
+    "fr": "Le séquenceur",
     "ru": "Секвенсор",
     "ro": "Secvențier",
     "it": "Sequenziatore"

--- a/sphere-chaos/app.json
+++ b/sphere-chaos/app.json
@@ -8,6 +8,7 @@
     "en": "Light beam",
     "de": "Lichtstrahl",
     "es": "Rayo de luz",
+    "fr": "Le faisceau lumineux",
     "zh": "光束",
     "ru": "Луч света",
     "ro": "Rază de lumină",

--- a/tree/app.json
+++ b/tree/app.json
@@ -8,6 +8,7 @@
     "en": "A Tree",
     "de": "Ein Baum",
     "es": "Árbol",
+    "fr": "Un arbre",
     "zh": "树",
     "ru": "Дерево",
     "ro": "Un copac",

--- a/whitney/app.json
+++ b/whitney/app.json
@@ -8,6 +8,7 @@
     "en": "Whitney Music Box",
     "de": "Whitney Spieluhr",
     "es": "Caja musical de Whitney",
+    "fr": "La boîte à musique de Whitney",
     "ru": "Музыкальная Шкатулка Уитни",
     "ro": "Cutia muzicală Whitney",
     "it": "Il carillon di Whitney"


### PR DESCRIPTION
The titles are as follows (due to Andreas):

> Euclidean Rhythm

Rythmes Euclidiens

> Pachelbel's Canon

Le canon de Pachelbel

> Mozart's Dice

Le dé de Mozart

> Whitney Music Box

La boîte à musique de Whitney

> Sequencer

Le séquenceur

> Double Pendulum

Le pendule double

> Light Beam

Le faisceau lumineux

> Car Park

Le parking

> Kaleidoscope

La kaléidoscope

> Spiral

Spirale

> A Tree

Un arbre

NOTE: they were also added into the general spreadsheet with translations.